### PR TITLE
fix(dictionary): add "field" to place names

### DIFF
--- a/resources/pelias/dictionaries/libpostal/en/place_names.txt
+++ b/resources/pelias/dictionaries/libpostal/en/place_names.txt
@@ -3,3 +3,4 @@ cathedral
 stop
 !dist
 building
+field

--- a/test/address.usa.test.js
+++ b/test/address.usa.test.js
@@ -1,6 +1,10 @@
 const testcase = (test, common) => {
   let assert = common.assert(test)
 
+  assert('wrigley field',
+    [ [ { place: 'wrigley field' } ], [ { street: 'wrigley field' } ], [ { locality: 'field' } ] ],
+    false)
+
   assert('Martin Luther King Jr. Blvd.', [
     { street: 'Martin Luther King Jr. Blvd.' }
   ])


### PR DESCRIPTION
* add field to place names

"field" is common in large baseball stadiums like wrigley field and citi
field

this will be paired with another PR for api that notices if the top two
interpretations are full street & place parses, and if so, boosts
neither

* move field to user contributed place names txt